### PR TITLE
Handle singly tagged packets properly

### DIFF
--- a/src/ethernet.rs
+++ b/src/ethernet.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn ethernet_frame_works() {
         let bytes = [0x00, 0x23, 0x54, 0x07, 0x93, 0x6c, /* dest MAC */
-                     0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b, /* src MAC */
+                     0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b, /* src MAC */ 
                      0x08, 0x00 // Ethertype
                     ];
         let expectation = EthernetFrame {

--- a/tests/icmp_packet.rs
+++ b/tests/icmp_packet.rs
@@ -29,7 +29,7 @@ mod tests {
         let eth_expectation = EthernetFrame {
             source_mac: MacAddress([0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b]),
             dest_mac: MacAddress([0x00, 0x23, 0x54, 0x07, 0x93, 0x6c]),
-            ethertype: EtherType::IPv4,
+            ethertype: EtherType::IPv4
         };
         let ip_expectation = IPv4Header {
             version: 4,

--- a/tests/icmp_packet.rs
+++ b/tests/icmp_packet.rs
@@ -29,7 +29,8 @@ mod tests {
         let eth_expectation = EthernetFrame {
             source_mac: MacAddress([0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b]),
             dest_mac: MacAddress([0x00, 0x23, 0x54, 0x07, 0x93, 0x6c]),
-            ethertype: EtherType::IPv4
+            ethertype: EtherType::IPv4,
+            vid: None,
         };
         let ip_expectation = IPv4Header {
             version: 4,

--- a/tests/icmp_packet.rs
+++ b/tests/icmp_packet.rs
@@ -30,7 +30,6 @@ mod tests {
             source_mac: MacAddress([0x00, 0x1b, 0x21, 0x0f, 0x91, 0x9b]),
             dest_mac: MacAddress([0x00, 0x23, 0x54, 0x07, 0x93, 0x6c]),
             ethertype: EtherType::IPv4,
-            vid: None,
         };
         let ip_expectation = IPv4Header {
             version: 4,


### PR DESCRIPTION
Might need a version bump since the public fields of EthernetFrame have changed.